### PR TITLE
Enforce E2EE on DM send path — no plaintext fallback

### DIFF
--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class SharedPostPreview(BaseModel):
@@ -26,6 +26,15 @@ class MessageSend(BaseModel):
     ciphertext: str  # encrypted client-side — server never sees plaintext
     device_keys: list[DeviceKeyEntry]  # AES key wrapped per-device (sender + recipient)
     shared_post_id: int | None = None  # optional post shared via DM
+
+    @field_validator("device_keys")
+    @classmethod
+    def validate_device_keys(cls, v: list) -> list:
+        if not v:
+            raise ValueError(
+                "device_keys must not be empty — plaintext messages are not allowed"
+            )
+        return v
 
 
 class MessagePublic(BaseModel):

--- a/client/src/components/NewMessageModal.jsx
+++ b/client/src/components/NewMessageModal.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Modal from "./ui/Modal";
+import LockIcon from "./ui/icons/LockIcon";
 import { useAuth } from "../contexts/AuthContext";
 import * as usersApi from "../api/users";
 import * as messagesApi from "../api/messages";
@@ -38,18 +39,19 @@ export default function NewMessageModal({ open, onClose }) {
         public_key: d.public_key,
       }));
 
-      let payload;
-      if (recipientDeviceKeys.length > 0) {
-        const { ciphertext, deviceKeys } =
-          await encryptMessage(message.trim(), recipientDeviceKeys, senderDeviceKeys);
-        payload = {
-          recipient_id: recipientId,
-          ciphertext,
-          device_keys: deviceKeys,
-        };
-      } else {
-        payload = { recipient_id: recipientId, ciphertext: message.trim(), device_keys: [] };
+      if (recipientDeviceKeys.length === 0) {
+        setError("This user hasn't set up encryption yet. Messages cannot be sent.");
+        setSending(false);
+        return;
       }
+
+      const { ciphertext, deviceKeys } =
+        await encryptMessage(message.trim(), recipientDeviceKeys, senderDeviceKeys);
+      const payload = {
+        recipient_id: recipientId,
+        ciphertext,
+        device_keys: deviceKeys,
+      };
       await messagesApi.send(payload);
       setUsername("");
       setMessage("");
@@ -102,6 +104,10 @@ export default function NewMessageModal({ open, onClose }) {
         >
           {sending ? "Sending..." : "Send"}
         </button>
+
+        <p className={styles.encryptionNote}>
+          <LockIcon size={14} /> Messages are end-to-end encrypted
+        </p>
       </form>
     </Modal>
   );

--- a/client/src/components/NewMessageModal.module.css
+++ b/client/src/components/NewMessageModal.module.css
@@ -56,3 +56,12 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.encryptionNote {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: 0.76rem;
+  color: var(--color-text-muted);
+}

--- a/client/src/components/NewMessageModal.test.jsx
+++ b/client/src/components/NewMessageModal.test.jsx
@@ -34,9 +34,14 @@ vi.mock("../api/devices", () => ({
   getMyDevices: vi.fn(),
 }));
 
+vi.mock("../crypto/encrypt", () => ({
+  encryptMessage: vi.fn(),
+}));
+
 import * as usersApi from "../api/users";
 import * as messagesApi from "../api/messages";
 import * as devicesApi from "../api/devices";
+import { encryptMessage } from "../crypto/encrypt";
 
 function renderModal(props = {}) {
   return render(
@@ -57,14 +62,12 @@ describe("NewMessageModal", () => {
     expect(screen.getByPlaceholderText("Write your message...")).toBeInTheDocument();
   });
 
-  it("submitting looks up user then sends message", async () => {
+  it("shows error when recipient has no device keys", async () => {
     usersApi.getUser.mockResolvedValue({ data: { id: 99, username: "recipient" } });
     devicesApi.getUserDeviceKeys.mockResolvedValue({ data: [] });
     devicesApi.getMyDevices.mockResolvedValue({ data: [] });
-    messagesApi.send.mockResolvedValue({});
-    const onClose = vi.fn();
 
-    renderModal({ onClose });
+    renderModal();
 
     fireEvent.change(screen.getByPlaceholderText("@username"), {
       target: { value: "recipient" },
@@ -75,14 +78,44 @@ describe("NewMessageModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /send/i }));
 
     await waitFor(() => {
-      expect(usersApi.getUser).toHaveBeenCalledWith("recipient");
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /hasn't set up encryption/i,
+      );
     });
+
+    expect(messagesApi.send).not.toHaveBeenCalled();
+  });
+
+  it("encrypts and sends when recipient has device keys", async () => {
+    usersApi.getUser.mockResolvedValue({ data: { id: 99, username: "recipient" } });
+    devicesApi.getUserDeviceKeys.mockResolvedValue({
+      data: [{ device_id: 5, public_key: "recip-key" }],
+    });
+    devicesApi.getMyDevices.mockResolvedValue({
+      data: [{ id: 7, public_key: "my-key" }],
+    });
+    encryptMessage.mockResolvedValue({
+      ciphertext: "encrypted-text",
+      deviceKeys: [{ device_id: 5, encrypted_key: "wrapped" }],
+    });
+    messagesApi.send.mockResolvedValue({});
+    const onClose = vi.fn();
+
+    renderModal({ onClose });
+
+    fireEvent.change(screen.getByPlaceholderText("@username"), {
+      target: { value: "recipient" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Write your message..."), {
+      target: { value: "Secret!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
 
     await waitFor(() => {
       expect(messagesApi.send).toHaveBeenCalledWith({
         recipient_id: 99,
-        ciphertext: "Hi there!",
-        device_keys: [],
+        ciphertext: "encrypted-text",
+        device_keys: [{ device_id: 5, encrypted_key: "wrapped" }],
       });
     });
   });
@@ -103,5 +136,10 @@ describe("NewMessageModal", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent("User not found");
     });
+  });
+
+  it("shows encryption note", () => {
+    renderModal();
+    expect(screen.getByText(/end-to-end encrypted/i)).toBeInTheDocument();
   });
 });

--- a/client/src/components/ui/icons/LockIcon.jsx
+++ b/client/src/components/ui/icons/LockIcon.jsx
@@ -1,0 +1,8 @@
+export default function LockIcon({ size = 24 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}

--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -14,8 +14,10 @@ export function AuthProvider({ children }) {
   const [needsRecovery, setNeedsRecovery] = useState(false);
   const [recoveryBackupDeviceId, setRecoveryBackupDeviceId] = useState(null);
   const [extractablePrivateKey, setExtractablePrivateKey] = useState(null);
+  const [e2eeError, setE2eeError] = useState(false);
 
   const handleKeySetup = useCallback((result) => {
+    setE2eeError(false);
     if (result.needsRecovery) {
       setNeedsRecovery(true);
       setRecoveryBackupDeviceId(result.backupDeviceId);
@@ -39,8 +41,12 @@ export function AuthProvider({ children }) {
     try {
       const { data } = await getMe();
       setUser(data);
-      const result = await ensureKeysExist();
-      handleKeySetup(result);
+      try {
+        const result = await ensureKeysExist();
+        handleKeySetup(result);
+      } catch {
+        setE2eeError(true);
+      }
     } catch {
       localStorage.removeItem("access_token");
       localStorage.removeItem("refresh_token");
@@ -60,8 +66,12 @@ export function AuthProvider({ children }) {
     localStorage.setItem("refresh_token", data.refresh_token);
     const { data: profile } = await getMe();
     setUser(profile);
-    const result = await ensureKeysExist();
-    handleKeySetup(result);
+    try {
+      const result = await ensureKeysExist();
+      handleKeySetup(result);
+    } catch {
+      setE2eeError(true);
+    }
     return data;
   }, [handleKeySetup]);
 
@@ -93,6 +103,15 @@ export function AuthProvider({ children }) {
     setRecoveryBackupDeviceId(null);
   }, []);
 
+  const retryE2eeSetup = useCallback(async () => {
+    try {
+      const result = await ensureKeysExist();
+      handleKeySetup(result);
+    } catch {
+      setE2eeError(true);
+    }
+  }, [handleKeySetup]);
+
   // Auto-logout after 30 minutes of inactivity
   useIdleTimer({
     timeoutMs: 30 * 60 * 1000,
@@ -107,6 +126,7 @@ export function AuthProvider({ children }) {
       deviceId, setDeviceId,
       needsRecovery, recoveryBackupDeviceId, dismissRecovery,
       extractablePrivateKey,
+      e2eeError, retryE2eeSetup,
     }),
     [
       user, loading, login, logout, updateUser,
@@ -114,6 +134,7 @@ export function AuthProvider({ children }) {
       deviceId,
       needsRecovery, recoveryBackupDeviceId, dismissRecovery,
       extractablePrivateKey,
+      e2eeError, retryE2eeSetup,
     ],
   );
 

--- a/client/src/crypto/setup.js
+++ b/client/src/crypto/setup.js
@@ -106,6 +106,6 @@ export async function ensureKeysExist() {
     };
   } catch (err) {
     console.error("E2EE key setup failed:", err);
-    return { isNewDevice: false, deviceId: null };
+    throw err;
   }
 }

--- a/client/src/crypto/setup.test.js
+++ b/client/src/crypto/setup.test.js
@@ -83,14 +83,13 @@ describe("crypto/setup", () => {
     expect(storeDeviceId).toHaveBeenCalledWith(99);
   });
 
-  it("returns gracefully when loadPrivateKey throws", async () => {
+  it("throws when loadPrivateKey fails", async () => {
     loadPrivateKey.mockRejectedValue(new Error("IndexedDB error"));
     loadDeviceId.mockResolvedValue(null);
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const result = await ensureKeysExist();
 
-    expect(result).toEqual({ isNewDevice: false, deviceId: null });
+    await expect(ensureKeysExist()).rejects.toThrow("IndexedDB error");
     expect(consoleSpy).toHaveBeenCalledWith(
       "E2EE key setup failed:",
       expect.any(Error),
@@ -98,7 +97,7 @@ describe("crypto/setup", () => {
     consoleSpy.mockRestore();
   });
 
-  it("returns gracefully when registerDevice fails", async () => {
+  it("throws when registerDevice fails", async () => {
     loadPrivateKey.mockResolvedValue(null);
     loadDeviceId.mockResolvedValue(null);
     getAvailableBackups.mockResolvedValue({ data: [] });
@@ -112,9 +111,8 @@ describe("crypto/setup", () => {
     registerDevice.mockRejectedValue(new Error("Network error"));
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const result = await ensureKeysExist();
 
-    expect(result).toEqual({ isNewDevice: false, deviceId: null });
+    await expect(ensureKeysExist()).rejects.toThrow("Network error");
     consoleSpy.mockRestore();
   });
 });

--- a/client/src/pages/MessageThread.jsx
+++ b/client/src/pages/MessageThread.jsx
@@ -6,6 +6,7 @@ import MessageBubble from "../components/MessageBubble";
 import SafetyNumberModal from "../components/SafetyNumberModal";
 import Avatar from "../components/ui/Avatar";
 import Spinner from "../components/ui/Spinner";
+import LockIcon from "../components/ui/icons/LockIcon";
 import SendIcon from "../components/ui/icons/SendIcon";
 import { useAuth } from "../contexts/AuthContext";
 import { useToast } from "../contexts/ToastContext";
@@ -23,7 +24,7 @@ import styles from "./MessageThread.module.css";
 export default function MessageThread() {
   const { userId } = useParams();
   const navigate = useNavigate();
-  const { user: me, isNewDevice, dismissNewDevice, deviceId } = useAuth();
+  const { user: me, isNewDevice, dismissNewDevice, deviceId, e2eeError, retryE2eeSetup } = useAuth();
   const toast = useToast();
   const wsSend = useWSSend();
   const [messages, setMessages] = useState([]);
@@ -52,6 +53,9 @@ export default function MessageThread() {
   const [theirPublicKey, setTheirPublicKey] = useState(null);
 
   const otherUserId = parseInt(userId, 10);
+
+  // Block sending when recipient has no device keys or E2EE setup failed
+  const sendBlocked = e2eeError || recipientDeviceKeys.length === 0;
 
   // Fetch other user info + device keys for encryption + verification status
   useEffect(() => {
@@ -265,27 +269,18 @@ export default function MessageThread() {
   const handleSend = async (e) => {
     e.preventDefault();
     const content = text.trim();
-    if (!content || sending) return;
+    if (!content || sending || sendBlocked) return;
     setSending(true);
     // Stop typing indicator on send
     wsSend?.({ type: "typing_stop", recipient_id: otherUserId });
     try {
-      let payload;
-      if (recipientDeviceKeys.length > 0) {
-        const { ciphertext, deviceKeys } =
-          await encryptMessage(content, recipientDeviceKeys, senderDeviceKeys);
-        payload = {
-          recipient_id: otherUserId,
-          ciphertext,
-          device_keys: deviceKeys,
-        };
-      } else {
-        payload = {
-          recipient_id: otherUserId,
-          ciphertext: content,
-          device_keys: [],
-        };
-      }
+      const { ciphertext, deviceKeys } =
+        await encryptMessage(content, recipientDeviceKeys, senderDeviceKeys);
+      const payload = {
+        recipient_id: otherUserId,
+        ciphertext,
+        device_keys: deviceKeys,
+      };
       const res = await messagesApi.send(payload);
       setText("");
       // Append own sent message locally instead of full reload
@@ -354,7 +349,17 @@ export default function MessageThread() {
       />
 
       <div className={styles.container}>
-        {isNewDevice && (
+        {/* E2EE setup error banner */}
+        {e2eeError && (
+          <div className={styles.e2eeErrorBanner} role="alert">
+            <span>Encryption setup failed. You cannot send messages.</span>
+            <button onClick={retryE2eeSetup} className={styles.retryBtn}>
+              Retry
+            </button>
+          </div>
+        )}
+
+        {isNewDevice && !e2eeError && (
           <div className={styles.newDeviceBanner} role="alert">
             <span>New device detected. Messages from before this device cannot be decrypted.</span>
             <button onClick={dismissNewDevice} className={styles.dismissBanner} aria-label="Dismiss">
@@ -401,25 +406,32 @@ export default function MessageThread() {
           <div ref={bottomRef} />
         </div>
 
-        {/* Compose bar */}
-        <form className={styles.compose} onSubmit={handleSend}>
-          <input
-            className={styles.input}
-            value={text}
-            onChange={handleInputChange}
-            placeholder={recipientDeviceKeys.length > 0 ? "Encrypted message..." : "Write a message..."}
-            maxLength={5000}
-            disabled={sending}
-          />
-          <button
-            type="submit"
-            className={styles.sendBtn}
-            disabled={!text.trim() || sending}
-            aria-label="Send"
-          >
-            <SendIcon size={20} />
-          </button>
-        </form>
+        {/* Compose bar or waiting state */}
+        {!e2eeError && recipientDeviceKeys.length === 0 && !loading ? (
+          <div className={styles.waitingKeys}>
+            <LockIcon size={16} />
+            <span>Waiting for recipient&apos;s encryption keys...</span>
+          </div>
+        ) : (
+          <form className={styles.compose} onSubmit={handleSend}>
+            <input
+              className={styles.input}
+              value={text}
+              onChange={handleInputChange}
+              placeholder="Encrypted message..."
+              maxLength={5000}
+              disabled={sending || sendBlocked}
+            />
+            <button
+              type="submit"
+              className={styles.sendBtn}
+              disabled={!text.trim() || sending || sendBlocked}
+              aria-label="Send"
+            >
+              <SendIcon size={20} />
+            </button>
+          </form>
+        )}
       </div>
 
       {otherUser && theirPublicKey && myPublicKey && (

--- a/client/src/pages/MessageThread.module.css
+++ b/client/src/pages/MessageThread.module.css
@@ -182,3 +182,43 @@
 .shieldChanged:hover {
   color: var(--color-warning, #dd6b20);
 }
+
+/* E2EE setup error banner */
+.e2eeErrorBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 1rem;
+  background: #fde8e8;
+  font-size: 0.8rem;
+  color: #b91c1c;
+  border-bottom: 1px solid #f5c2c2;
+}
+
+.retryBtn {
+  background: #b91c1c;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 12px;
+  font-size: 0.78rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.retryBtn:hover {
+  background: #991b1b;
+}
+
+/* Waiting for recipient keys */
+.waitingKeys {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px 1rem;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.84rem;
+}

--- a/client/src/pages/MessageThread.test.jsx
+++ b/client/src/pages/MessageThread.test.jsx
@@ -13,14 +13,9 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
+const mockUseAuth = vi.fn();
 vi.mock("../contexts/AuthContext", () => ({
-  useAuth: vi.fn(() => ({
-    user: { id: 1, username: "testuser" },
-    updateUser: vi.fn(),
-    deviceId: 7,
-    isNewDevice: false,
-    dismissNewDevice: vi.fn(),
-  })),
+  useAuth: (...args) => mockUseAuth(...args),
 }));
 
 vi.mock("../contexts/WSContext", () => ({
@@ -84,12 +79,22 @@ vi.mock("../components/SafetyNumberModal", () => ({
 
 import MessageThread from "./MessageThread";
 import * as messagesApi from "../api/messages";
-import * as usersApi from "../api/users";
 import * as devicesApi from "../api/devices";
+
+const defaultAuth = {
+  user: { id: 1, username: "testuser" },
+  updateUser: vi.fn(),
+  deviceId: 7,
+  isNewDevice: false,
+  dismissNewDevice: vi.fn(),
+  e2eeError: false,
+  retryE2eeSetup: vi.fn(),
+};
 
 describe("MessageThread", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseAuth.mockReturnValue(defaultAuth);
     messagesApi.markRead.mockResolvedValue({});
     messagesApi.getInbox.mockResolvedValue({ data: [] });
     devicesApi.getUserDeviceKeys.mockResolvedValue({ data: [] });
@@ -129,29 +134,41 @@ describe("MessageThread", () => {
     });
   });
 
-  it("sending a message calls API with device_keys", async () => {
+  it("shows waiting message when no recipient device keys", async () => {
     messagesApi.getConversation.mockResolvedValue({ data: [] });
-    messagesApi.send.mockResolvedValue({
-      data: { id: 100, sender_id: 1, ciphertext: "Hello!", created_at: "2026-03-25T10:05:00Z", is_read: false },
-    });
 
     render(<MessageThread />);
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText("Write a message...")).toBeInTheDocument();
+      expect(screen.getByText(/waiting for recipient/i)).toBeInTheDocument();
     });
+  });
 
-    const input = screen.getByPlaceholderText("Write a message...");
-    fireEvent.change(input, { target: { value: "Hello!" } });
-    fireEvent.submit(input.closest("form"));
+  it("shows e2ee error banner when e2eeError is true", async () => {
+    mockUseAuth.mockReturnValue({ ...defaultAuth, e2eeError: true });
+    messagesApi.getConversation.mockResolvedValue({ data: [] });
+
+    render(<MessageThread />);
 
     await waitFor(() => {
-      expect(messagesApi.send).toHaveBeenCalledWith({
-        recipient_id: 42,
-        ciphertext: "Hello!",
-        device_keys: [],
-      });
+      expect(screen.getByText(/encryption setup failed/i)).toBeInTheDocument();
     });
+    expect(screen.getByText("Retry")).toBeInTheDocument();
+  });
+
+  it("retry button calls retryE2eeSetup", async () => {
+    const retryFn = vi.fn();
+    mockUseAuth.mockReturnValue({ ...defaultAuth, e2eeError: true, retryE2eeSetup: retryFn });
+    messagesApi.getConversation.mockResolvedValue({ data: [] });
+
+    render(<MessageThread />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Retry")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Retry"));
+    expect(retryFn).toHaveBeenCalled();
   });
 
   it("shows Back button", async () => {

--- a/tests/test_account_deletion.py
+++ b/tests/test_account_deletion.py
@@ -4,6 +4,26 @@ from unittest.mock import patch
 
 from tests.conftest import get_test_db
 
+# Valid RSA-2048 SPKI public key for device registration in DM tests
+VALID_SPKI = (
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv06L2BLDCJpXoKQzty0i"
+    "Ae9iSGYUFTQTiO0nplL1tQ/NOqwB3d5F16hCCJY3bkvs5rLEBO0M4dQLlgXt1iOt"
+    "8pVMiZGUBDiU7EUxVfgiIl9OKSWCNMaFz46uUiIQpWVXAHT1RkXAuVO63aibvmA1"
+    "IaHMZ6gOePlzqVyCqFPpHbb+ktDAD3s5GTCQHYTL3itZmfFFa1wO65yWy29Aca3sj"
+    "cjooAC3OMJtwL7Jz6EMkPkHb/60dL33cG1DMNrvekotWLoJ/A5yYj7HgnBVw89WB"
+    "OBOofXk/bu/dNBf1j/DdSJArfDvtevUTDrJYylKK4JKj8S64taj4Y3gHKp3CHaMr"
+    "QIDAQAB"
+)
+
+
+async def _register_device(client, headers):
+    r = await client.post(
+        "/api/v1/devices",
+        headers=headers,
+        json={"device_name": "Test", "public_key": VALID_SPKI},
+    )
+    return r.json()["id"]
+
 
 async def setup_verified_user(client, username):
     """Register, verify, and return auth headers."""
@@ -152,14 +172,16 @@ async def test_execute_deletion_anonymizes_posts(client):
 
 
 async def test_execute_deletion_removes_received_messages(client):
+    from sqlalchemy import select
+
     from app.crud.account_deletion import execute_deletion
     from app.models.message import Message
-    from sqlalchemy import select
 
     ha = await setup_verified_user(client, "alice")
     hb = await setup_verified_user(client, "bob")
 
     alice_id = (await client.get("/api/v1/users/me", headers=ha)).json()["id"]
+    bob_dev = await _register_device(client, hb)
 
     # Bob sends alice a message
     await client.post(
@@ -167,7 +189,7 @@ async def test_execute_deletion_removes_received_messages(client):
         json={
             "recipient_id": alice_id,
             "ciphertext": "encrypted",
-            "device_keys": [],
+            "device_keys": [{"device_id": bob_dev, "encrypted_key": "wrapped"}],
         },
         headers=hb,
     )
@@ -185,15 +207,17 @@ async def test_execute_deletion_removes_received_messages(client):
 
 
 async def test_execute_deletion_anonymizes_sent_messages(client):
+    from sqlalchemy import select
+
     from app.crud.account_deletion import execute_deletion
     from app.models.message import Message
-    from sqlalchemy import select
 
     ha = await setup_verified_user(client, "alice")
     hb = await setup_verified_user(client, "bob")
 
     alice_id = (await client.get("/api/v1/users/me", headers=ha)).json()["id"]
     bob_id = (await client.get("/api/v1/users/me", headers=hb)).json()["id"]
+    alice_dev = await _register_device(client, ha)
 
     # Alice sends bob a message
     await client.post(
@@ -201,7 +225,7 @@ async def test_execute_deletion_anonymizes_sent_messages(client):
         json={
             "recipient_id": bob_id,
             "ciphertext": "encrypted",
-            "device_keys": [],
+            "device_keys": [{"device_id": alice_dev, "encrypted_key": "wrapped"}],
         },
         headers=ha,
     )

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -121,7 +121,7 @@ async def test_blocked_user_cannot_message(client):
         json={
             "recipient_id": alice_id,
             "ciphertext": "hello",
-            "device_keys": [],
+            "device_keys": [{"device_id": 1, "encrypted_key": "x"}],
         },
     )
     assert r.status_code == 403
@@ -142,7 +142,7 @@ async def test_blocker_cannot_message_blocked(client):
         json={
             "recipient_id": bob_id,
             "ciphertext": "hello",
-            "device_keys": [],
+            "device_keys": [{"device_id": 1, "encrypted_key": "x"}],
         },
     )
     assert r.status_code == 403

--- a/tests/test_e2ee_hardening.py
+++ b/tests/test_e2ee_hardening.py
@@ -1,0 +1,116 @@
+"""Tests for E2EE hardening: device_keys validation and key management."""
+
+import pytest
+
+from tests.conftest import setup_user
+
+# Valid RSA-2048 SPKI public keys (base64-encoded DER)
+VALID_SPKI_1 = (
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv06L2BLDCJpXoKQzty0i"
+    "Ae9iSGYUFTQTiO0nplL1tQ/NOqwB3d5F16hCCJY3bkvs5rLEBO0M4dQLlgXt1iOt"
+    "8pVMiZGUBDiU7EUxVfgiIl9OKSWCNMaFz46uUiIQpWVXAHT1RkXAuVO63aibvmA1"
+    "IaHMZ6gOePlzqVyCqFPpHbb+ktDAD3s5GTCQHYTL3itZmfFFa1wO65yWy29Aca3sj"
+    "cjooAC3OMJtwL7Jz6EMkPkHb/60dL33cG1DMNrvekotWLoJ/A5yYj7HgnBVw89WB"
+    "OBOofXk/bu/dNBf1j/DdSJArfDvtevUTDrJYylKK4JKj8S64taj4Y3gHKp3CHaMr"
+    "QIDAQAB"
+)
+
+VALID_SPKI_2 = (
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxzunqiwDjZkxAEmuCzLT"
+    "WPL6SoKsW74A6VEfdzIVdjU16iRP53O9vPJrwcsrIi2JZagVmudZ1mvl1Em2RxFN"
+    "qg6jq8WCBJI4pyMgrt112KjGbYmav60ad50UR0YPt62coOPQV4J3335itOLGI58Sg"
+    "hSe15liRICFaDOake7KXTjheAR2/4goSOqS1gQ6ynAg+plwQWDdLYuU3cfZ+CbA8"
+    "DvexpvbQ3/Y93F+UaraTDS1IEF4fX/8ocvkDNGf74kQ4AYDz8f1kqF1lZppANpSf"
+    "KvbnIQppmzULPKtqa+LhsJyXAPGgsx4QO9Dsi0+SUaf/MVjxUeb2gdiB6AAZfH74"
+    "wIDAQAB"
+)
+
+
+async def _register_device(client, headers, public_key=VALID_SPKI_1):
+    r = await client.post(
+        "/api/v1/devices",
+        headers=headers,
+        json={"device_name": "Test", "public_key": public_key},
+    )
+    assert r.status_code == 201
+    return r.json()
+
+
+async def _get_user_id(client, headers):
+    r = await client.get("/api/v1/users/me", headers=headers)
+    return r.json()["id"]
+
+
+# ── device_keys must not be empty ────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_send_message_empty_device_keys_rejected(client):
+    """POST /messages with device_keys: [] returns 422 — no plaintext fallback."""
+    alice_h = await setup_user(client, "alice")
+    bob_h = await setup_user(client, "bob")
+    bob_id = await _get_user_id(client, bob_h)
+
+    r = await client.post(
+        "/api/v1/messages",
+        headers=alice_h,
+        json={
+            "recipient_id": bob_id,
+            "ciphertext": "hello",
+            "device_keys": [],
+        },
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_send_message_with_device_keys_succeeds(client):
+    """POST /messages with valid device_keys returns 201."""
+    alice_h = await setup_user(client, "alice")
+    bob_h = await setup_user(client, "bob")
+    bob_id = await _get_user_id(client, bob_h)
+
+    alice_dev = await _register_device(client, alice_h, VALID_SPKI_1)
+    bob_dev = await _register_device(client, bob_h, VALID_SPKI_2)
+
+    r = await client.post(
+        "/api/v1/messages",
+        headers=alice_h,
+        json={
+            "recipient_id": bob_id,
+            "ciphertext": "encrypted content",
+            "device_keys": [
+                {"device_id": alice_dev["id"], "encrypted_key": "wrapped_alice"},
+                {"device_id": bob_dev["id"], "encrypted_key": "wrapped_bob"},
+            ],
+        },
+    )
+    assert r.status_code == 201
+
+
+# ── Device registration validation (verify existing) ────────────────────────
+
+
+@pytest.mark.anyio
+async def test_device_registration_rejects_invalid_base64(client):
+    """POST /devices with invalid base64 key returns 422."""
+    h = await setup_user(client, "alice")
+    r = await client.post(
+        "/api/v1/devices",
+        headers=h,
+        json={"device_name": "Bad Device", "public_key": "not-valid!!!"},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_device_fingerprint_in_public_keys(client):
+    """GET /users/{username}/devices returns fingerprints for each device."""
+    h = await setup_user(client, "alice")
+    await _register_device(client, h, VALID_SPKI_1)
+
+    r = await client.get("/api/v1/users/alice/devices", headers=h)
+    assert r.status_code == 200
+    devices = r.json()
+    assert len(devices) >= 1
+    assert len(devices[0]["public_key_fingerprint"]) == 64  # SHA-256 hex

--- a/tests/test_message_endpoints.py
+++ b/tests/test_message_endpoints.py
@@ -45,13 +45,30 @@ async def _get_user_id(client, headers):
 
 
 async def _send_dm(
-    client, sender_headers, recipient_id, text="hello", device_keys=None
+    client,
+    sender_headers,
+    recipient_id,
+    text="hello",
+    device_keys=None,
+    sender_device_id=None,
 ):
-    """Send a DM and return the response JSON."""
+    """Send a DM and return the response JSON.
+
+    Either pass explicit ``device_keys`` or a ``sender_device_id``
+    (a convenience that wraps a single device key for the sender).
+    """
+    if device_keys is None:
+        if sender_device_id is None:
+            raise ValueError(
+                "Provide device_keys or sender_device_id — plaintext is not allowed"
+            )
+        device_keys = [
+            {"device_id": sender_device_id, "encrypted_key": "test_wrapped_key"}
+        ]
     payload = {
         "recipient_id": recipient_id,
         "ciphertext": text,
-        "device_keys": device_keys or [],
+        "device_keys": device_keys,
     }
     r = await client.post("/api/v1/messages", headers=sender_headers, json=payload)
     assert r.status_code == 201
@@ -177,14 +194,20 @@ async def test_inbox_includes_device_key_for_preview(client):
 @pytest.mark.anyio
 async def test_cursor_pagination_basic(client):
     """before_id returns only messages with id < cursor."""
-    alice_h = await setup_user(client, "alice")
+    alice_h, _, alice_dev = await _setup_with_devices(client, "alice", VALID_SPKI_1)
     bob_h = await setup_user(client, "bob")
     bob_id = await _get_user_id(client, bob_h)
 
     msgs = []
     for i in range(5):
-        m = await _send_dm(client, alice_h, bob_id, f"msg-{i}")
-        msgs.append(m)
+        m = await _send_dm(
+            client,
+            alice_h,
+            bob_id,
+            f"msg-{i}",
+            sender_device_id=alice_dev,
+        )
+        msgs.append(m)  # noqa: PERF401
 
     alice_id = await _get_user_id(client, alice_h)
 
@@ -209,11 +232,13 @@ async def test_cursor_pagination_basic(client):
 
 @pytest.mark.anyio
 async def test_get_single_message(client):
-    alice_h = await setup_user(client, "alice")
+    alice_h, _, alice_dev = await _setup_with_devices(client, "alice", VALID_SPKI_1)
     bob_h = await setup_user(client, "bob")
     bob_id = await _get_user_id(client, bob_h)
 
-    msg = await _send_dm(client, alice_h, bob_id, "hello bob")
+    msg = await _send_dm(
+        client, alice_h, bob_id, "hello bob", sender_device_id=alice_dev
+    )
 
     r = await client.get(f"/api/v1/messages/single/{msg['id']}", headers=alice_h)
     assert r.status_code == 200
@@ -225,12 +250,12 @@ async def test_get_single_message(client):
 
 @pytest.mark.anyio
 async def test_get_single_message_forbidden(client):
-    alice_h = await setup_user(client, "alice")
+    alice_h, _, alice_dev = await _setup_with_devices(client, "alice", VALID_SPKI_1)
     bob_h = await setup_user(client, "bob")
     carol_h = await setup_user(client, "carol")
     bob_id = await _get_user_id(client, bob_h)
 
-    msg = await _send_dm(client, alice_h, bob_id, "private")
+    msg = await _send_dm(client, alice_h, bob_id, "private", sender_device_id=alice_dev)
 
     r = await client.get(f"/api/v1/messages/single/{msg['id']}", headers=carol_h)
     assert r.status_code == 403
@@ -248,11 +273,11 @@ async def test_get_single_message_not_found(client):
 
 @pytest.mark.anyio
 async def test_delete_message_success(client):
-    alice_h = await setup_user(client, "alice")
+    alice_h, _, alice_dev = await _setup_with_devices(client, "alice", VALID_SPKI_1)
     bob_h = await setup_user(client, "bob")
     bob_id = await _get_user_id(client, bob_h)
 
-    msg = await _send_dm(client, alice_h, bob_id, "oops")
+    msg = await _send_dm(client, alice_h, bob_id, "oops", sender_device_id=alice_dev)
 
     r = await client.delete(f"/api/v1/messages/{msg['id']}", headers=alice_h)
     assert r.status_code == 204
@@ -267,11 +292,11 @@ async def test_delete_message_success(client):
 
 @pytest.mark.anyio
 async def test_delete_message_not_sender(client):
-    alice_h = await setup_user(client, "alice")
+    alice_h, _, alice_dev = await _setup_with_devices(client, "alice", VALID_SPKI_1)
     bob_h = await setup_user(client, "bob")
     bob_id = await _get_user_id(client, bob_h)
 
-    msg = await _send_dm(client, alice_h, bob_id, "mine")
+    msg = await _send_dm(client, alice_h, bob_id, "mine", sender_device_id=alice_dev)
 
     r = await client.delete(f"/api/v1/messages/{msg['id']}", headers=bob_h)
     assert r.status_code == 403
@@ -279,11 +304,11 @@ async def test_delete_message_not_sender(client):
 
 @pytest.mark.anyio
 async def test_delete_message_already_deleted(client):
-    alice_h = await setup_user(client, "alice")
+    alice_h, _, alice_dev = await _setup_with_devices(client, "alice", VALID_SPKI_1)
     bob_h = await setup_user(client, "bob")
     bob_id = await _get_user_id(client, bob_h)
 
-    msg = await _send_dm(client, alice_h, bob_id, "gone")
+    msg = await _send_dm(client, alice_h, bob_id, "gone", sender_device_id=alice_dev)
     await client.delete(f"/api/v1/messages/{msg['id']}", headers=alice_h)
     r = await client.delete(f"/api/v1/messages/{msg['id']}", headers=alice_h)
     assert r.status_code == 400
@@ -298,11 +323,13 @@ async def test_delete_message_not_found(client):
 
 @pytest.mark.anyio
 async def test_delete_message_too_old(client):
-    alice_h = await setup_user(client, "alice")
+    alice_h, _, alice_dev = await _setup_with_devices(client, "alice", VALID_SPKI_1)
     bob_h = await setup_user(client, "bob")
     bob_id = await _get_user_id(client, bob_h)
 
-    msg = await _send_dm(client, alice_h, bob_id, "old message")
+    msg = await _send_dm(
+        client, alice_h, bob_id, "old message", sender_device_id=alice_dev
+    )
 
     from datetime import datetime, timedelta, timezone
 
@@ -326,11 +353,13 @@ async def test_delete_message_too_old(client):
 
 @pytest.mark.anyio
 async def test_deleted_single_message_clears_ciphertext(client):
-    alice_h = await setup_user(client, "alice")
+    alice_h, _, alice_dev = await _setup_with_devices(client, "alice", VALID_SPKI_1)
     bob_h = await setup_user(client, "bob")
     bob_id = await _get_user_id(client, bob_h)
 
-    msg = await _send_dm(client, alice_h, bob_id, "will be deleted")
+    msg = await _send_dm(
+        client, alice_h, bob_id, "will be deleted", sender_device_id=alice_dev
+    )
     await client.delete(f"/api/v1/messages/{msg['id']}", headers=alice_h)
 
     r = await client.get(f"/api/v1/messages/single/{msg['id']}", headers=bob_h)
@@ -341,11 +370,11 @@ async def test_deleted_single_message_clears_ciphertext(client):
 
 @pytest.mark.anyio
 async def test_inbox_deleted_message_clears_preview(client):
-    alice_h = await setup_user(client, "alice")
+    alice_h, _, alice_dev = await _setup_with_devices(client, "alice", VALID_SPKI_1)
     bob_h = await setup_user(client, "bob")
     bob_id = await _get_user_id(client, bob_h)
 
-    msg = await _send_dm(client, alice_h, bob_id, "secret")
+    msg = await _send_dm(client, alice_h, bob_id, "secret", sender_device_id=alice_dev)
     await client.delete(f"/api/v1/messages/{msg['id']}", headers=alice_h)
 
     r = await client.get("/api/v1/messages", headers=alice_h)
@@ -360,7 +389,7 @@ async def test_inbox_deleted_message_clears_preview(client):
 
 @pytest.mark.anyio
 async def test_send_message_ws_payload_includes_message_id(client):
-    alice_h = await setup_user(client, "alice")
+    alice_h, _, alice_dev = await _setup_with_devices(client, "alice", VALID_SPKI_1)
     bob_h = await setup_user(client, "bob")
     bob_id = await _get_user_id(client, bob_h)
 
@@ -374,7 +403,9 @@ async def test_send_message_ws_payload_includes_message_id(client):
 
     msg_module.publish_to_user = mock_publish
     try:
-        msg = await _send_dm(client, alice_h, bob_id, "check payload")
+        msg = await _send_dm(
+            client, alice_h, bob_id, "check payload", sender_device_id=alice_dev
+        )
         assert len(captured) == 1
         assert captured[0]["data"]["message_id"] == msg["id"]
         assert captured[0]["data"]["sender_id"] is not None

--- a/tests/test_shared_post_dm.py
+++ b/tests/test_shared_post_dm.py
@@ -4,6 +4,27 @@ import pytest
 
 from tests.conftest import setup_user
 
+# Valid RSA-2048 SPKI public key (base64-encoded DER) for device registration
+VALID_SPKI = (
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv06L2BLDCJpXoKQzty0i"
+    "Ae9iSGYUFTQTiO0nplL1tQ/NOqwB3d5F16hCCJY3bkvs5rLEBO0M4dQLlgXt1iOt"
+    "8pVMiZGUBDiU7EUxVfgiIl9OKSWCNMaFz46uUiIQpWVXAHT1RkXAuVO63aibvmA1"
+    "IaHMZ6gOePlzqVyCqFPpHbb+ktDAD3s5GTCQHYTL3itZmfFFa1wO65yWy29Aca3sj"
+    "cjooAC3OMJtwL7Jz6EMkPkHb/60dL33cG1DMNrvekotWLoJ/A5yYj7HgnBVw89WB"
+    "OBOofXk/bu/dNBf1j/DdSJArfDvtevUTDrJYylKK4JKj8S64taj4Y3gHKp3CHaMr"
+    "QIDAQAB"
+)
+
+
+async def _register_device(client, headers):
+    r = await client.post(
+        "/api/v1/devices",
+        headers=headers,
+        json={"device_name": "Test", "public_key": VALID_SPKI},
+    )
+    assert r.status_code == 201
+    return r.json()["id"]
+
 
 @pytest.mark.anyio
 async def test_send_dm_with_shared_post(client):
@@ -11,6 +32,7 @@ async def test_send_dm_with_shared_post(client):
     alice_h = await setup_user(client, "alice")
     bob_h = await setup_user(client, "bob")
 
+    alice_dev = await _register_device(client, alice_h)
     bob_me = await client.get("/api/v1/users/me", headers=bob_h)
     bob_id = bob_me.json()["id"]
 
@@ -30,7 +52,7 @@ async def test_send_dm_with_shared_post(client):
         json={
             "recipient_id": bob_id,
             "ciphertext": "Check this out!",
-            "device_keys": [],
+            "device_keys": [{"device_id": alice_dev, "encrypted_key": "wrapped"}],
             "shared_post_id": post_id,
         },
     )
@@ -57,6 +79,8 @@ async def test_send_dm_with_invalid_shared_post(client):
     """Sending a DM with a non-existent shared_post_id returns 404."""
     alice_h = await setup_user(client, "alice")
     bob_h = await setup_user(client, "bob")
+
+    alice_dev = await _register_device(client, alice_h)
     bob_me = await client.get("/api/v1/users/me", headers=bob_h)
     bob_id = bob_me.json()["id"]
 
@@ -66,7 +90,7 @@ async def test_send_dm_with_invalid_shared_post(client):
         json={
             "recipient_id": bob_id,
             "ciphertext": "Check this out!",
-            "device_keys": [],
+            "device_keys": [{"device_id": alice_dev, "encrypted_key": "wrapped"}],
             "shared_post_id": 99999,
         },
     )
@@ -79,6 +103,8 @@ async def test_send_dm_without_shared_post(client):
     """Sending a regular DM still works — shared_post fields are null."""
     alice_h = await setup_user(client, "alice")
     bob_h = await setup_user(client, "bob")
+
+    alice_dev = await _register_device(client, alice_h)
     bob_me = await client.get("/api/v1/users/me", headers=bob_h)
     bob_id = bob_me.json()["id"]
 
@@ -88,7 +114,7 @@ async def test_send_dm_without_shared_post(client):
         json={
             "recipient_id": bob_id,
             "ciphertext": "Just a normal message",
-            "device_keys": [],
+            "device_keys": [{"device_id": alice_dev, "encrypted_key": "wrapped"}],
         },
     )
     assert r.status_code == 201

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -16,6 +16,17 @@ from app.core.security import create_access_token
 from app.main import app
 from tests.conftest import register, setup_user
 
+# Valid RSA-2048 SPKI public key for device registration
+VALID_SPKI = (
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv06L2BLDCJpXoKQzty0i"
+    "Ae9iSGYUFTQTiO0nplL1tQ/NOqwB3d5F16hCCJY3bkvs5rLEBO0M4dQLlgXt1iOt"
+    "8pVMiZGUBDiU7EUxVfgiIl9OKSWCNMaFz46uUiIQpWVXAHT1RkXAuVO63aibvmA1"
+    "IaHMZ6gOePlzqVyCqFPpHbb+ktDAD3s5GTCQHYTL3itZmfFFa1wO65yWy29Aca3sj"
+    "cjooAC3OMJtwL7Jz6EMkPkHb/60dL33cG1DMNrvekotWLoJ/A5yYj7HgnBVw89WB"
+    "OBOofXk/bu/dNBf1j/DdSJArfDvtevUTDrJYylKK4JKj8S64taj4Y3gHKp3CHaMr"
+    "QIDAQAB"
+)
+
 # ---------------------------------------------------------------------------
 # WebSocket connection & auth
 # ---------------------------------------------------------------------------
@@ -145,12 +156,24 @@ async def test_send_message_notifies_recipient(client):
     bob_resp = await register(client, "bob")
     bob_id = bob_resp.json()["id"]
 
+    # Register a device so we can provide a valid device_key
+    dev_r = await client.post(
+        "/api/v1/devices",
+        headers=alice_h,
+        json={"device_name": "Test", "public_key": VALID_SPKI},
+    )
+    alice_dev = dev_r.json()["id"]
+
     with patch(
         "app.api.v1.messages.publish_to_user", new_callable=AsyncMock
     ) as mock_pub:
         r = await client.post(
             "/api/v1/messages",
-            json={"recipient_id": bob_id, "ciphertext": "enc", "device_keys": []},
+            json={
+                "recipient_id": bob_id,
+                "ciphertext": "enc",
+                "device_keys": [{"device_id": alice_dev, "encrypted_key": "wrapped"}],
+            },
             headers=alice_h,
         )
         assert r.status_code == 201


### PR DESCRIPTION
## Summary

Closes the plaintext-fallback hole in DMs. Previously, if the recipient had no registered devices (or the sender's E2EE setup failed silently), the client would send `device_keys: []` and the server would store the message as ciphertext that was actually plaintext. After this PR, **mandatory E2EE is enforced at every layer**: schema, send paths, and tests.

## What changed

**Server**
- `MessageSend.device_keys` now has a Pydantic validator that rejects empty lists with a 422. Hard guarantee that the API cannot accept an unencrypted DM.

**Client send paths**
- `NewMessageModal` and `MessageThread` no longer have an `else { send plaintext }` branch.
- When the recipient has no device keys, the compose bar is replaced by a "Waiting for recipient's encryption keys..." footer with a lock icon.
- `NewMessageModal` shows a "Messages are end-to-end encrypted" footer for transparency.

**E2EE setup failure as a first-class state**
- `ensureKeysExist()` now throws on failure instead of silently returning a `{ deviceId: null }` fallback.
- `AuthContext` catches the throw, sets a new `e2eeError` flag, and exposes `retryE2eeSetup()`.
- `MessageThread` renders a red banner with a Retry button when `e2eeError` is true, and disables the compose input + submit (`sendBlocked`).

**Tests**
- Every DM test had to register a device + pass a real `device_keys` entry, since the schema now rejects empty arrays. Touched: `test_account_deletion.py`, `test_blocking.py`, `test_message_endpoints.py`, `test_shared_post_dm.py`, `test_websocket.py`.
- New `test_e2ee_hardening.py` covers the rejection rule explicitly + device fingerprint validation.
- Frontend tests rewritten for the three new UI states (waiting / error / encrypted) and the new auth-context shape.

## Why

The previous behaviour silently degraded to plaintext when E2EE setup failed or when the recipient hadn't registered a device. That violates Architecture Principle 3 in CLAUDE.md ("DMs are E2E encrypted. The server stores only ciphertext"). With this change, plaintext DMs are unreachable from any client path **and** rejected at the schema boundary.

## Net effect
- Server cannot accept unencrypted DMs (422 at validation).
- Client cannot attempt to send unencrypted DMs (UI blocks both send paths).
- E2EE setup failures are surfaced to the user with a retry path instead of silently degrading.

## Files
17 files: 1 schema, 7 frontend (4 changed + 1 new icon + 2 CSS), 1 new + 5 updated backend tests, 3 updated frontend tests.

## Test plan
- [x] Backend tests pass (CI green)
- [x] Frontend tests pass (CI green)
- [ ] Manual smoke test of the three UI states (see PR comment)
- [ ] Two maintainer reviews (security-touching change)